### PR TITLE
Improve LIDC preprocessing pipeline

### DIFF
--- a/lidc_preprocessing_pipeline.py
+++ b/lidc_preprocessing_pipeline.py
@@ -7,9 +7,9 @@ para que qualquer modelo (2_D, 2.5_D, 3_D) possa ser preparado em passos posteri
 Estrutura de saída
 ==================
 processed_lidc_general/
-├─ volumes/           patientID.npz   «volume» int16 HU (Z,Y,X)
-├─ masks/             patientID_mask.npz   «nodule_mask» uint8 (Z,Y,X)
-├─ lung_masks/        patientID_lung.npz   «lung_mask» uint8 (Z,Y,X)
+├─ volumes/           patientID_scanID.npz         «volume» int16 HU (Z,Y,X)
+├─ masks/             patientID_scanID_mask.npz    «nodule_mask» uint8 (Z,Y,X)
+├─ lung_masks/        patientID_scanID_lung.npz    «lung_mask» uint8 (Z,Y,X)
 └─ metadata.parquet   tabela por *scan* (id, dims, n_nódulos, split)
 
 Características principais
@@ -63,12 +63,19 @@ def resample(vol: np.ndarray, spacing: np.ndarray, tgt: Tuple[float, float, floa
     return ndi.zoom(vol, zoom, order=1)
 
 
+def resample_mask(mask: np.ndarray, spacing: np.ndarray, tgt: Tuple[float, float, float]) -> np.ndarray:
+    """Resample binary mask using nearest-neighbour interpolation."""
+    zoom = spacing / np.array(tgt)
+    return ndi.zoom(mask.astype(float), zoom, order=0)
+
+
 def build_consensus(scan: pl.Scan, shape: Tuple[int, int, int], thr: float) -> np.ndarray:
+    """Return majority vote mask in the original scan resolution."""
     stacks = []
     for ann in scan.cluster_annotations():
         m, (z0, y0, x0) = ann.boolean_mask(loc=True)
         tmp = np.zeros(shape, np.uint8)
-        tmp[z0:z0+m.shape[0], y0:y0+m.shape[1], x0:x0+m.shape[2]] = m
+        tmp[z0:z0 + m.shape[0], y0:y0 + m.shape[1], x0:x0 + m.shape[2]] = m
         stacks.append(tmp)
     if not stacks:
         return np.zeros(shape, np.uint8)
@@ -98,17 +105,20 @@ def main(cfg: Config):
     rows: List[dict] = []
     for scan in pl.query(pl.Scan):
         try:
-            vol_hu, spacing, _ = scan.to_volume()
-            vol_hu = vol_hu.astype(np.int16)
-            vol_hu = resample(vol_hu, spacing, cfg.voxel_spacing)
+            vol_orig, spacing, _ = scan.to_volume()
+            vol_orig = vol_orig.astype(np.int16)
 
-            nodule_mask = build_consensus(scan, vol_hu.shape, cfg.consensus_thr)
+            consensus = build_consensus(scan, vol_orig.shape, cfg.consensus_thr)
+
+            vol_hu = resample(vol_orig, spacing, cfg.voxel_spacing)
+            nodule_mask = resample_mask(consensus, spacing, cfg.voxel_spacing).astype(np.uint8)
             lung = lung_mask(vol_hu)
 
             # Salvar arquivos -------------------------------------------------
-            vol_path = cfg.out_dir / "volumes" / f"{scan.patient_id}.npz"
-            mask_path = cfg.out_dir / "masks" / f"{scan.patient_id}_mask.npz"
-            lung_path = cfg.out_dir / "lung_masks" / f"{scan.patient_id}_lung.npz"
+            base = f"{scan.patient_id}_{scan.id}"
+            vol_path = cfg.out_dir / "volumes" / f"{base}.npz"
+            mask_path = cfg.out_dir / "masks" / f"{base}_mask.npz"
+            lung_path = cfg.out_dir / "lung_masks" / f"{base}_lung.npz"
             np.savez_compressed(vol_path, volume=vol_hu)
             np.savez_compressed(mask_path, nodule_mask=nodule_mask)
             np.savez_compressed(lung_path, lung_mask=lung)
@@ -119,9 +129,9 @@ def main(cfg: Config):
                 "z": vol_hu.shape[0], "y": vol_hu.shape[1], "x": vol_hu.shape[2],
                 "n_nodules": int(nodule_mask.any()),
             })
-            print(f"✔ {scan.patient_id}")
+            print(f"✔ {scan.patient_id}/{scan.id}")
         except Exception as e:
-            print(f"⚠ {scan.patient_id}: {e}")
+            print(f"⚠ {scan.patient_id}/{scan.id}: {e}")
 
     meta = pd.DataFrame(rows)
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,26 @@
+import numpy as np
+from lidc_preprocessing_pipeline import resample, resample_mask, lung_mask
+
+
+def test_resample_shapes():
+    vol = np.ones((2, 2, 2))
+    spacing = np.array([2.0, 2.0, 2.0])
+    out = resample(vol, spacing, (1.0, 1.0, 1.0))
+    assert out.shape == (4, 4, 4)
+
+
+def test_resample_mask():
+    mask = np.zeros((1, 1, 1), dtype=np.uint8)
+    mask[0, 0, 0] = 1
+    spacing = np.array([2.0, 2.0, 2.0])
+    out = resample_mask(mask, spacing, (1.0, 1.0, 1.0))
+    assert out.shape == (2, 2, 2)
+    assert np.allclose(out.sum(), 8)
+
+
+def test_lung_mask():
+    vol = np.full((2, 2, 2), -400)
+    mask = lung_mask(vol)
+    assert mask.shape == vol.shape
+    assert mask.dtype == np.uint8
+

--- a/visual_check.py
+++ b/visual_check.py
@@ -1,0 +1,30 @@
+import random
+from pathlib import Path
+import numpy as np
+import pandas as pd
+import matplotlib.pyplot as plt
+
+
+def main(out_dir="processed_lidc_general", seed=0):
+    out_dir = Path(out_dir)
+    meta = pd.read_parquet(out_dir / "metadata.parquet")
+    rng = random.Random(seed)
+    row = meta.sample(1, random_state=rng.randint(0, 10000)).iloc[0]
+
+    base = f"{row.patient_id}_{row.scan_id}"
+    vol = np.load(out_dir / "volumes" / f"{base}.npz")['volume']
+    mask = np.load(out_dir / "masks" / f"{base}_mask.npz")['nodule_mask']
+    lung = np.load(out_dir / "lung_masks" / f"{base}_lung.npz")['lung_mask']
+
+    z = vol.shape[0] // 2
+    fig, ax = plt.subplots(1, 1)
+    ax.imshow(vol[z], cmap='gray')
+    ax.imshow(lung[z], alpha=0.2, cmap='Blues')
+    ax.imshow(mask[z], alpha=0.4, cmap='Reds')
+    ax.set_title(f"{base} slice {z}")
+    ax.axis('off')
+    plt.show()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- fix mask alignment by resampling annotations
- add visual inspection utility
- add simple unit tests for utility functions
- clarify output filenames to avoid collisions

## Testing
- `python -m py_compile lidc_preprocessing_pipeline.py`
- `python -m py_compile visual_check.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_683f724790cc832f83311edb07d63d32